### PR TITLE
Address Git SSH URL warning

### DIFF
--- a/OpenTracingSwift.podspec
+++ b/OpenTracingSwift.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
     spec.summary       = 'Swift implementation of the OpenTracing standard'
 
     spec.source = {
-        :git => 'git@github.com:lightstep/opentracing-swift.git',
+        :git => 'https://github.com/lightstep/opentracing-swift.git',
         :tag => spec.version
     }
 


### PR DESCRIPTION
    - WARN  | source: Git SSH URLs will NOT work for people behind firewalls configured to only allow HTTP, therefore HTTPS is preferred.